### PR TITLE
Add logging/observability infrastructure (#27)

### DIFF
--- a/src/Bartleby.App/Bartleby.App.csproj
+++ b/src/Bartleby.App/Bartleby.App.csproj
@@ -17,6 +17,7 @@
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<LangVersion>preview</LangVersion>
 
 		<!-- Display name -->
 		<ApplicationTitle>Bartleby</ApplicationTitle>

--- a/src/Bartleby.App/ViewModels/BlockedViewModel.cs
+++ b/src/Bartleby.App/ViewModels/BlockedViewModel.cs
@@ -14,19 +14,19 @@ public partial class BlockedViewModel : ObservableObject
     private readonly ILogger<BlockedViewModel>? _logger;
 
     [ObservableProperty]
-    private ObservableCollection<BlockedQuestionDisplay> _questions = [];
+    public partial ObservableCollection<BlockedQuestionDisplay> Questions { get; set; }
 
     [ObservableProperty]
-    private BlockedQuestionDisplay? _selectedQuestion;
+    public partial BlockedQuestionDisplay? SelectedQuestion { get; set; }
 
     [ObservableProperty]
-    private string _answerText = string.Empty;
+    public partial string AnswerText { get; set; }
 
     [ObservableProperty]
-    private bool _isLoading;
+    public partial bool IsLoading { get; set; }
 
     [ObservableProperty]
-    private string? _errorMessage;
+    public partial string? ErrorMessage { get; set; }
 
     public BlockedViewModel(
         IBlockedQuestionRepository questionRepository,
@@ -36,6 +36,8 @@ public partial class BlockedViewModel : ObservableObject
         _questionRepository = questionRepository;
         _workItemRepository = workItemRepository;
         _logger = logger;
+        Questions = [];
+        AnswerText = string.Empty;
     }
 
     [RelayCommand(IncludeCancelCommand = true)]

--- a/src/Bartleby.App/ViewModels/DashboardViewModel.cs
+++ b/src/Bartleby.App/ViewModels/DashboardViewModel.cs
@@ -11,16 +11,16 @@ public partial class DashboardViewModel : ObservableObject
     private readonly ISettingsRepository _settingsRepository;
 
     [ObservableProperty]
-    private int _totalWorkItems;
+    public partial int TotalWorkItems { get; set; }
 
     [ObservableProperty]
-    private int _readyItems;
+    public partial int ReadyItems { get; set; }
 
     [ObservableProperty]
-    private int _inProgressItems;
+    public partial int InProgressItems { get; set; }
 
     [ObservableProperty]
-    private int _blockedItems;
+    public partial int BlockedItems { get; set; }
 
     /// <summary>
     /// Indicates whether there are blocked items requiring attention.
@@ -31,16 +31,16 @@ public partial class DashboardViewModel : ObservableObject
         => OnPropertyChanged(nameof(HasBlockedItems));
 
     [ObservableProperty]
-    private int _completedItems;
+    public partial int CompletedItems { get; set; }
 
     [ObservableProperty]
-    private bool _orchestratorEnabled;
+    public partial bool OrchestratorEnabled { get; set; }
 
     [ObservableProperty]
-    private string _orchestratorStatus = "Stopped";
+    public partial string OrchestratorStatus { get; set; }
 
     [ObservableProperty]
-    private bool _isLoading;
+    public partial bool IsLoading { get; set; }
 
     public DashboardViewModel(
         IWorkItemRepository workItemRepository,
@@ -48,6 +48,7 @@ public partial class DashboardViewModel : ObservableObject
     {
         _workItemRepository = workItemRepository;
         _settingsRepository = settingsRepository;
+        OrchestratorStatus = "Stopped";
     }
 
     [RelayCommand]

--- a/src/Bartleby.App/ViewModels/SettingsViewModel.cs
+++ b/src/Bartleby.App/ViewModels/SettingsViewModel.cs
@@ -13,37 +13,37 @@ public partial class SettingsViewModel : ObservableObject
 
     // Azure OpenAI
     [ObservableProperty]
-    private string _azureOpenAIEndpoint = string.Empty;
+    public partial string AzureOpenAIEndpoint { get; set; }
 
     [ObservableProperty]
-    private string _azureOpenAIApiKey = string.Empty;
+    public partial string AzureOpenAIApiKey { get; set; }
 
     [ObservableProperty]
-    private string _azureOpenAIDeploymentName = string.Empty;
+    public partial string AzureOpenAIDeploymentName { get; set; }
 
     // GitHub
     [ObservableProperty]
-    private string _gitHubToken = string.Empty;
+    public partial string GitHubToken { get; set; }
 
     [ObservableProperty]
-    private string _gitHubOwner = string.Empty;
+    public partial string GitHubOwner { get; set; }
 
     [ObservableProperty]
-    private string _gitHubRepo = string.Empty;
+    public partial string GitHubRepo { get; set; }
 
     // Orchestrator
     [ObservableProperty]
-    private bool _orchestratorEnabled;
+    public partial bool OrchestratorEnabled { get; set; }
 
     [ObservableProperty]
-    private int _orchestratorIntervalMinutes = 5;
+    public partial int OrchestratorIntervalMinutes { get; set; }
 
     // Status
     [ObservableProperty]
-    private string _statusMessage = string.Empty;
+    public partial string StatusMessage { get; set; }
 
     [ObservableProperty]
-    private bool _isLoading;
+    public partial bool IsLoading { get; set; }
 
     public SettingsViewModel(
         ISettingsRepository settingsRepository,
@@ -53,6 +53,14 @@ public partial class SettingsViewModel : ObservableObject
         _settingsRepository = settingsRepository;
         _aiProvider = aiProvider;
         _workSource = workSource;
+        AzureOpenAIEndpoint = string.Empty;
+        AzureOpenAIApiKey = string.Empty;
+        AzureOpenAIDeploymentName = string.Empty;
+        GitHubToken = string.Empty;
+        GitHubOwner = string.Empty;
+        GitHubRepo = string.Empty;
+        OrchestratorIntervalMinutes = 5;
+        StatusMessage = string.Empty;
     }
 
     [RelayCommand]

--- a/src/Bartleby.App/ViewModels/WorkItemsViewModel.cs
+++ b/src/Bartleby.App/ViewModels/WorkItemsViewModel.cs
@@ -12,16 +12,16 @@ public partial class WorkItemsViewModel : ObservableObject
     private readonly IWorkSource _workSource;
 
     [ObservableProperty]
-    private ObservableCollection<WorkItem> _workItems = [];
+    public partial ObservableCollection<WorkItem> WorkItems { get; set; }
 
     [ObservableProperty]
-    private WorkItem? _selectedWorkItem;
+    public partial WorkItem? SelectedWorkItem { get; set; }
 
     [ObservableProperty]
-    private bool _isLoading;
+    public partial bool IsLoading { get; set; }
 
     [ObservableProperty]
-    private string _filterStatus = "All";
+    public partial string FilterStatus { get; set; }
 
     public WorkItemsViewModel(
         IWorkItemRepository workItemRepository,
@@ -29,6 +29,8 @@ public partial class WorkItemsViewModel : ObservableObject
     {
         _workItemRepository = workItemRepository;
         _workSource = workSource;
+        WorkItems = [];
+        FilterStatus = "All";
     }
 
     [RelayCommand]

--- a/src/Bartleby.App/Views/DashboardPage.xaml
+++ b/src/Bartleby.App/Views/DashboardPage.xaml
@@ -20,7 +20,8 @@
                    HorizontalOptions="Center"/>
 
             <!-- Orchestrator Status -->
-            <Frame Padding="15" BackgroundColor="{AppThemeBinding Light=#F0F0F0, Dark=#2A2A2A}">
+            <Border Padding="15" BackgroundColor="{AppThemeBinding Light=#F0F0F0, Dark=#2A2A2A}"
+                    StrokeShape="RoundRectangle 5" Stroke="Transparent">
                 <VerticalStackLayout Spacing="10">
                     <Label Text="Orchestrator" FontSize="18" FontAttributes="Bold"/>
                     <HorizontalStackLayout Spacing="10">
@@ -34,36 +35,39 @@
                                 HorizontalOptions="EndAndExpand"/>
                     </HorizontalStackLayout>
                 </VerticalStackLayout>
-            </Frame>
+            </Border>
 
             <!-- Stats Grid -->
             <Label Text="Work Items" FontSize="18" FontAttributes="Bold"/>
             <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="10" RowSpacing="10">
 
-                <Frame Grid.Row="0" Grid.Column="0" Padding="15" BackgroundColor="#4CAF50">
+                <Border Grid.Row="0" Grid.Column="0" Padding="15" BackgroundColor="#4CAF50"
+                        StrokeShape="RoundRectangle 5" Stroke="Transparent">
                     <VerticalStackLayout>
                         <Label Text="{Binding ReadyItems}" FontSize="36" FontAttributes="Bold" TextColor="White" HorizontalOptions="Center"/>
                         <Label Text="Ready" TextColor="White" HorizontalOptions="Center"/>
                     </VerticalStackLayout>
-                </Frame>
+                </Border>
 
-                <Frame Grid.Row="0" Grid.Column="1" Padding="15" BackgroundColor="#2196F3">
+                <Border Grid.Row="0" Grid.Column="1" Padding="15" BackgroundColor="#2196F3"
+                        StrokeShape="RoundRectangle 5" Stroke="Transparent">
                     <VerticalStackLayout>
                         <Label Text="{Binding InProgressItems}" FontSize="36" FontAttributes="Bold" TextColor="White" HorizontalOptions="Center"/>
                         <Label Text="In Progress" TextColor="White" HorizontalOptions="Center"/>
                     </VerticalStackLayout>
-                </Frame>
+                </Border>
 
-                <Frame Grid.Row="1" Grid.Column="0" Padding="15" BackgroundColor="#FF9800"
-                       x:Name="BlockedFrame">
-                    <Frame.Triggers>
-                        <DataTrigger TargetType="Frame"
+                <Border Grid.Row="1" Grid.Column="0" Padding="15" BackgroundColor="#FF9800"
+                        StrokeShape="RoundRectangle 5" Stroke="Transparent"
+                        x:Name="BlockedFrame">
+                    <Border.Triggers>
+                        <DataTrigger TargetType="Border"
                                      Binding="{Binding HasBlockedItems}"
                                      Value="True">
-                            <Setter Property="BorderColor" Value="#FF1744"/>
-                            <Setter Property="HasShadow" Value="True"/>
+                            <Setter Property="Stroke" Value="#FF1744"/>
+                            <Setter Property="StrokeThickness" Value="2"/>
                         </DataTrigger>
-                    </Frame.Triggers>
+                    </Border.Triggers>
                     <VerticalStackLayout>
                         <Label Text="{Binding BlockedItems}" FontSize="36" FontAttributes="Bold" TextColor="White" HorizontalOptions="Center"/>
                         <Label Text="Blocked" TextColor="White" HorizontalOptions="Center"/>
@@ -74,14 +78,15 @@
                                HorizontalOptions="Center"
                                IsVisible="{Binding HasBlockedItems}"/>
                     </VerticalStackLayout>
-                </Frame>
+                </Border>
 
-                <Frame Grid.Row="1" Grid.Column="1" Padding="15" BackgroundColor="#9C27B0">
+                <Border Grid.Row="1" Grid.Column="1" Padding="15" BackgroundColor="#9C27B0"
+                        StrokeShape="RoundRectangle 5" Stroke="Transparent">
                     <VerticalStackLayout>
                         <Label Text="{Binding CompletedItems}" FontSize="36" FontAttributes="Bold" TextColor="White" HorizontalOptions="Center"/>
                         <Label Text="Completed" TextColor="White" HorizontalOptions="Center"/>
                     </VerticalStackLayout>
-                </Frame>
+                </Border>
             </Grid>
 
             <Label Text="{Binding TotalWorkItems, StringFormat='Total: {0} work items'}"

--- a/src/Bartleby.App/Views/DashboardPage.xaml.cs
+++ b/src/Bartleby.App/Views/DashboardPage.xaml.cs
@@ -77,9 +77,9 @@ public partial class DashboardPage : ContentPage
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                await BlockedFrame.ScaleTo(1.05, 500, Easing.SinInOut);
+                await BlockedFrame.ScaleToAsync(1.05, 500, Easing.SinInOut);
                 if (cancellationToken.IsCancellationRequested) break;
-                await BlockedFrame.ScaleTo(1.0, 500, Easing.SinInOut);
+                await BlockedFrame.ScaleToAsync(1.0, 500, Easing.SinInOut);
             }
         }
         catch (TaskCanceledException)

--- a/src/Bartleby.Infrastructure/Persistence/WorkItemRepository.cs
+++ b/src/Bartleby.Infrastructure/Persistence/WorkItemRepository.cs
@@ -15,13 +15,13 @@ public class WorkItemRepository : IWorkItemRepository
     public Task<WorkItem?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
         var item = _context.WorkItems.FindById(id);
-        return Task.FromResult(item);
+        return Task.FromResult<WorkItem?>(item);
     }
 
     public Task<WorkItem?> GetByExternalIdAsync(string source, string externalId, CancellationToken cancellationToken = default)
     {
         var item = _context.WorkItems.FindOne(x => x.Source == source && x.ExternalId == externalId);
-        return Task.FromResult(item);
+        return Task.FromResult<WorkItem?>(item);
     }
 
     public Task<IEnumerable<WorkItem>> GetAllAsync(CancellationToken cancellationToken = default)
@@ -70,7 +70,7 @@ public class BlockedQuestionRepository : IBlockedQuestionRepository
     public Task<BlockedQuestion?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
         var item = _context.BlockedQuestions.FindById(id);
-        return Task.FromResult(item);
+        return Task.FromResult<BlockedQuestion?>(item);
     }
 
     public Task<IEnumerable<BlockedQuestion>> GetByWorkItemIdAsync(Guid workItemId, CancellationToken cancellationToken = default)
@@ -117,7 +117,7 @@ public class WorkSessionRepository : IWorkSessionRepository
     public Task<WorkSession?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
         var item = _context.WorkSessions.FindById(id);
-        return Task.FromResult(item);
+        return Task.FromResult<WorkSession?>(item);
     }
 
     public Task<IEnumerable<WorkSession>> GetByWorkItemIdAsync(Guid workItemId, CancellationToken cancellationToken = default)

--- a/tests/Bartleby.Infrastructure.Tests/Git/GitServiceTests.cs
+++ b/tests/Bartleby.Infrastructure.Tests/Git/GitServiceTests.cs
@@ -273,7 +273,7 @@ public class GitServiceTests
         var branchesMock = new Mock<BranchCollection>();
         branchesMock
             .Setup(b => b[expectedBranchName])
-            .Returns((Branch?)null);
+            .Returns((Branch)null!);
 
         var newBranchMock = new Mock<Branch>();
         newBranchMock.Setup(b => b.FriendlyName).Returns(expectedBranchName);
@@ -554,7 +554,7 @@ public class GitServiceTests
     {
         // Arrange
         var remotesMock = new Mock<RemoteCollection>();
-        remotesMock.Setup(r => r["nonexistent"]).Returns((Remote?)null);
+        remotesMock.Setup(r => r["nonexistent"]).Returns((Remote)null!);
 
         var networkMock = new Mock<Network>();
         networkMock.Setup(n => n.Remotes).Returns(remotesMock.Object);
@@ -637,8 +637,8 @@ public class GitServiceTests
         var configEntry = CreateConfigEntry("user.name", "Bartleby");
         var emailEntry = CreateConfigEntry("user.email", "bartleby@test.com");
 
-        configMock.Setup(c => c.Get<string>("user.name")).Returns(configEntry);
-        configMock.Setup(c => c.Get<string>("user.email")).Returns(emailEntry);
+        configMock.Setup(c => c.Get<string>("user.name")).Returns(configEntry!);
+        configMock.Setup(c => c.Get<string>("user.email")).Returns(emailEntry!);
 
         _repositoryMock.Setup(r => r.Config).Returns(configMock.Object);
 
@@ -678,7 +678,7 @@ public class GitServiceTests
     {
         var headMock = new Mock<Branch>();
         headMock.Setup(h => h.FriendlyName).Returns(currentBranch);
-        headMock.Setup(h => h.TrackedBranch).Returns((Branch?)null);
+        headMock.Setup(h => h.TrackedBranch).Returns((Branch)null!);
 
         var statusMock = new Mock<RepositoryStatus>();
         statusMock.Setup(s => s.IsDirty).Returns(hasModified || hasStaged || hasUntracked);

--- a/tests/Bartleby.Infrastructure.Tests/WorkSources/GitHubWorkSourceTests.cs
+++ b/tests/Bartleby.Infrastructure.Tests/WorkSources/GitHubWorkSourceTests.cs
@@ -97,7 +97,7 @@ public class GitHubWorkSourceTests
         var issue = CreateIssue(1, "Test Issue", "Test body");
 
         _gitHubApiClientMock
-            .Setup(c => c.GetIssuesAsync(_defaultSettings.GitHubOwner, _defaultSettings.GitHubRepo, It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetIssuesAsync(_defaultSettings.GitHubOwner!, _defaultSettings.GitHubRepo!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<GitHubIssue> { issue });
 
         // Act
@@ -587,7 +587,9 @@ public class GitHubWorkSourceTests
     public void Constructor_WithNullClientFactory_ThrowsArgumentNullException()
     {
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new GitHubWorkSource(_settingsRepositoryMock.Object, null!));
+        Assert.Throws<ArgumentNullException>(() => new GitHubWorkSource(
+            _settingsRepositoryMock.Object,
+            (Func<string?, IGitHubApiClient>)null!));
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Add structured logging to key infrastructure services (GitHubWorkSource, OctokitGitHubApiClient, SyncService)
- Log exceptions in `TestConnectionAsync` and other operations that previously failed silently
- Fix pre-existing build warnings (Frame → Border, ScaleTo → ScaleToAsync, nullability issues)
- Migrate ViewModels to partial property syntax to fix MVVMTK0045 AOT warnings

Closes #27

## Changes

### Logging Infrastructure
- **GitHubWorkSource**: Log exceptions in `TestConnectionAsync()` and `GetIssueByNumberAsync()`
- **OctokitGitHubApiClient**: Log connection test results and failures
- **SyncService**: Log sync lifecycle (start, item counts, completion, errors)

### Build Warning Fixes
- **DashboardPage.xaml**: Migrate deprecated `Frame` to `Border` with `StrokeShape`
- **DashboardPage.xaml.cs**: Replace `ScaleTo` with `ScaleToAsync`
- **WorkItemRepository.cs**: Fix nullable `Task.FromResult<T?>()` signatures
- **GitServiceTests.cs/GitHubWorkSourceTests.cs**: Fix null mock returns

### MVVMTK0045 AOT Compatibility
- Add `LangVersion=preview` to enable partial property source generation
- Migrate all 27 ViewModel properties from field-based to partial property syntax
- Move field initializers to constructors (required for partial properties)

## Test plan
- [x] Build succeeds with 0 warnings
- [x] All 348 tests pass
- [ ] Manual test: Verify logging appears in debug output for GitHub operations
- [ ] Manual test: Verify UI renders correctly after Frame → Border migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)